### PR TITLE
fix(proceedings): sort by page number

### DIFF
--- a/conference/mec_proceedings.bib
+++ b/conference/mec_proceedings.bib
@@ -1696,11 +1696,13 @@ The future development of suitable software can facilitate interdisciplinary stu
 }
 
 
+
+
 %%% -------------------------------
 %%% MEC 2025 Proceedings: Book of Abstracts
 
 @proceedings{Lewis-Plaksin-Stremel_2025,
-  title = {{Music Encoding Conference 2025 – Book of Abstracts}},
+  title = {{Music Encoding Conference 2025 -- Book of Abstracts}},
   editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
   year = {2025},
   publisher = {Knowledge Commons},
@@ -1719,7 +1721,7 @@ The future development of suitable software can facilitate interdisciplinary stu
   abstract = {Foreword of the Music Encoding Conference 2025 Book of Abstracts.},
   author = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
   title = {{Foreword}},
-  booktitle = {{Music Encoding Conference 2025 – Book of Abstracts}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
   editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
   publisher = {Knowledge Commons},
   year = {2025},
@@ -1768,214 +1770,19 @@ The future development of suitable software can facilitate interdisciplinary stu
 }
 
 %%% -------------------------------
-%%% MEC 2025 Proceedings: Papers
+%%% MEC 2025 Proceedings: Long Papers
 
-@inproceedings{Alemayehu_2025,
-  title = {{Community-Driven Open Source Development of Edirom Online 1.0 and Beyond}},
+@inproceedings{Yang_2025,
+  title = {{Music with Numbers: \textit{Jianpu} Number-Based Notation in Cultural Heritage and Digital Humanities}},
   booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Alemayehu, Hizkiel and Bachmann, Tobias and Beer, Nikolaos and Bohl, Benjamin and Friedl, Dennis and R{\"o}wenstrunk, Daniel and Ried, Dennis and Herold, Kristin and Jettka, Daniel and Kepper, Johannes and Reich, Silke and Stadler, Peter},
+  author = {Yang, Rui and Giraud, Mathieu and Lev{\'e}, Florence},
   editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
   year = {2025},
-  pages = {167--170},
+  pages = {12--24},
   publisher = {Knowledge Commons},
-  doi = {10.17613/9q5gf-sbn97},
+  doi = {10.17613/cjjtg-yar17},
   urldate = {2025-07-08},
-  abstract = {Edirom-Online is a software for the presentation and analysis of critical musical editions in a digital format, particularly in the fields of musicology and philology. Edirom-Online supports various data formats commonly used in digital humanities, such as TEI (Text Encoding Initiative) for textual data and MEI (Music Encoding Initiative) for musical data, that is visualized with Verovio. This allows for the integration of different data formats, starting in the early days with texts, images and music and adding audio and even film within a single edition. The Edirom idea was born in 2004 at Musikwissenschaftliches Seminar Detmold/Paderborn and even after several years of Edirom development, the success of Edirom based on the same core concepts as in the beginning continues with numerous projects using and developing Edirom tools and creating digital musical editions with this software. Edirom tools were originally developed by the project Entwicklung von Werkzeugen f{\"u}r digitale Formen wissenschaftlich-kritischer Musikeditionen (2006--2012) funded by the DFG. The development of Edirom is now maintained as a community effort while being strongly supported and accompanied by Virtueller Forschungsverbund Edirom (ViFE), primarily based at Paderborn University. This poster aims to celebrate the release of the first stable version of Edirom and as a demonstration of successful collaboration in open source research software development.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Arjmand_2025,
-  title = {{A Step Forward in Lute Tablature Studies with \textit{MEI.Tablature}}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Arjmand, Ailin and Seyedi, Reza},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {132--135},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/frpq3-ytw66},
-  urldate = {2025-07-08},
-  abstract = {The Tablatures from the Albani Collection project, a collaboration between the Ricercar Lab at the Centre d'{\'E}tudes Sup{\'e}rieures de la Renaissance (Tours, France) and the Ente Olivieri in Pesaro (Italy), focuses on the rediscovered Albani archives: a collection of 38 music manuscripts containing lute music from the late Renaissance and early Baroque periods. By adopting the MEI.tablature module, the project encodes musical incipits, enriches them with detailed metadata, and integrates the results into the Ricercar database, making these valuable resources openly accessible through a IIIF viewer. The initiative tackles significant challenges related to MEI.tablature, including its limitations for early lute notation and the constraints of existing tools like Verovio, MuseScore, and Luteconv. To address these issues, the project introduces R{\'e}Tab, a web-based application designed to simplify and enhance the encoding of lute tablature. R{\'e}Tab offers a streamlined, customizable workflow, ensures synchronization between visualized tablature and MEI code, and accommodates historical notational practices. This project represents a notable advancement in digital musicology, contributing to the refinement of MEI.tablature and fostering broader adoption of standardized tools for music encoding. By providing open-access resources and innovative solutions, it paves the way for future research and digital dissemination of Renaissance musical heritage.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Bonde_2025,
-  title = {Enhancing the Experience of Contemporary Classical Music through Dynamic, Interactive Visualisation},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Bonde, Anders and Meredith, David},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {127--131},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/5qj0w-jsn47},
-  urldate = {2025-07-08},
-  abstract = {We explore the problem of designing dynamic, interactive visualisations in order to enhance the experience of contemporary classical music. We aim to address the well-recognized problem that contemporary classical music (CCM) receives minimal media attention and lacks prominent dissemination in mainstream culture. Recent empirical studies (Emerson, 2020) have suggested that adding appropriate extra-musical and audiovisual elements to a CCM performance can attract newcomers to this type of music and enhance audience experience. We identify four dilemmas that emerge when designing an effective visualisation, specifically, that a visualisation should (1) enhance the experience without distracting listeners from the music itself; (2) guide listeners through the music without constraining their interpretation; (3) possibly provide listeners with the option to control their experience, subject to the user interface being self-explanatory and only to the extent that this does not distract attention from the music; and (4) provide listeners with a means to locate themselves within the music, but without disclosing the music's development prematurely.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Cerveto-Serrano_2025,
-  title = {{Kernpy: A Humdrum **Kern Oriented Python Package for Optical Music Recognition Tasks}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {{Cerveto-Serrano}, Joan and Rizo, David and {Calvo-Zaragoza}, Jorge},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {178--183},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/qhvtd-hkv52},
-  urldate = {2025-07-09},
-  abstract = {We present kernpy, a Python package that provides comprehensive tools for working with symbolic modern and mensural notations in Humdrum format. It serves as an intermediary tool for data extraction and significantly enhances the performance of Optical Music Recognition Python workflows. kernpy addresses the scarcity of symbolic score datasets in **kern/**mens by enabling the creation of large-scale datasets. By integrating formal grammars, kernpy offers a unified software for handling Humdrum files within a single, cohesive and user-friendly interface. kernpy is a fully open-source project open to contributions available at https://github.com/OMR-PRAIG-UA-ES/kernpy.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Cividini_2025,
-  title = {{Switching Between Standard and Original Score Order: Encoding, Transforming and Rendering Alternative Score Definitions in Digital Music Editions}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Cividini, Iacopo and {Mair-Gruber}, Roland and {Sapov-Erlinger}, Oleksii},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {61--65},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/n7h15-jtq15},
-  urldate = {2025-07-08},
-  abstract = {Printed music editions face a critical dilemma in the definition of the score order. On the one hand, the standard score order established in the 20th century offers several practical advantages: it allows for a more compact score by grouping individual parts on a single staff, and it provides a convention that is broadly accepted and used for editions of works from all historical periods. On the other hand, the standard score order often differs significantly from the original parts arrangement chosen by the composer. As a result, it may overlook important aspects of the compositional process and the composer's intention in structuring the score in a particular way. Furthermore, the standard score order may no longer reflect the historical ensemble configuration originally intended by the composer, which could affect the performance interpretation of the work. For these reasons, some printed music editions have restored the original order of the scores. Using Mozart's Exsultate, jubilate KV 165 as a case study, the paper discusses a solution to the editorial dilemma in a digital edition by offering the option to choose between alternative score configurations. By encoding each part of a score in MEI as a semantically independent layer, each part can be relocated into alternative score configurations using a dedicated transformation tool. As a result, the MEI file, originally encoded in one score order, can potentially be displayed in any other score order. This finally enables switching between the standard and the original score order in a web application.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Desmond_2025,
-  title = {{The Encoding of Insular Polyphony in English Mensural and Pre-mensural Notations}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Desmond, Karen},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {112--115},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/2zcma-hb133},
-  urldate = {2025-07-08},
-  abstract = {The Music Encoding Initiative currently has two fairly robust modules for the encoding of vocal repertoire notated in important medieval notation systems, namely the MEI Neumes module (for plainchant) and the MEI Mensural Notation module (for polyphony). Franco's systematic rule-based system for mensural notation made a significant intervention in the history of music when he asserted that the notational symbol (the 'figure') ought to represent a fixed duration. But a significant portion of the western European polyphonic repertoire is notated in notations that preceded Franco's rule-based system that associated fixed durations to specific symbols, including, for example, the Aquitanian and Parisian polyphonic repertoires. BROKENSONG, a five-year project funded by an ERC Consolidator Grant, examines polyphonic singing and written culture in late medieval Britain and Ireland, from c. 1150-c. 1350. As part of the project, the entire extant repertoire is being encoded (approximately 600 compositions, many of them fragmentary, notated in approximately 120 fragmentary manuscript sources). While many compositions are notated in Franconian and extended Franconian notations, a large portion of the repertoire is notated in notations that can be broadly categorized as either modal, modal with Insular characteristics, and pre-mensural or mensural with Insular characteristics (Bent, Wibberley, Lefferts, Losseff). These notations are more flexible than standard Franconian notation and frequently informed by local practice. The interpretation may be dependent on notational dialects used in a particular geographic location, or by a particular scribe, or indeed the interpretation may be unclear. In this paper, I introduce two case studies from the BROKENSONG repertoire copied in Insular notation and present some of the most significant issues related to their encoding.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Dvorakova_2025,
-  title = {{Visualizing Gregorian Traditions: ChantMapper}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Dvo{\v{r}}{\'a}kov{\'a}, Anna and {Haji{\v{c}} jr.}, Jan},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {143--151},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/g378z-ppk48},
-  urldate = {2025-07-08},
-  abstract = {One of the major topics in Gregorian chant scholarship is the study of chant transmission and traditions: systematizing the variability of chant repertoire witnessed in sources across medieval Europe. Given that several hundred chant sources have been digitally catalogued, there is a clear opportunity for computational methods, but in the absence of ground truth against which to measure their accuracy, manual inspection of results by experts remains necessary. This in turn requires appropriate user interfaces for visualizing the results. Given that locations -- or transregionality -- are part of what defines the identity of a chant tradition, we believe this interface should involve a map. Hence, we present ChantMapper: a pilot web application for computational analysis of chant repertoire on a map. The interface can be used both to analyse traditions found by known methods (exemplified by Louvain community detection), as well as to inspect results of proposed methods (e.g. topic models). While the application provides a large dataset of antiphons and responsories extracted via Cantus Index and enriched with geocoding information users can upload their own datasets as well.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Einbond_2025,
-  title = {{Encoding Interactive, Immersive, and Generative Electroacoustic Music}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Einbond, Aaron},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {118--124},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/ee60x-jd298},
-  urldate = {2025-07-08},
-  abstract = {This short paper is presented as an invitation to explore the challenges of encoding music for instruments and interactive electronics including elements of immersive 3-D sound and generative computer improvisation. The topic of encoding electronic music has been addressed in the context of fixed media (Zwi{\ss}ler et al., 2021) but interactive electronics present specific challenges: it may involve acoustic instruments accompanied by computer, and both of these may vary from performance to performance due to human and computer improvisation. Further, the notation of the electronic part may follow different strategies from that of the acoustic instruments, including timbral and spatial information that can be specified using audio descriptors and higher order Ambisonics (HOA). A work for solo percussion and interactive 3-D electronics is presented as a case study to highlight these challenges.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Fiala_2025,
-  title = {{A New XML Conversion Process for Mensural Music Encoding : CMME\_to\_MEI (via Verovio)}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Fiala, David and Pugin, Laurent and {van Berchum}, Marnix and Thomae, Martha and Roger, K{\'e}vin},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {31--35},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/gwvsx-q0c26},
-  urldate = {2025-07-08},
-  abstract = {The Ricercar Lab --- the musicological research team at the Center for advanced Studies in the Renaissance at the University of Tours --- has decided to make available in open access, thanks to the support of the French digital infrastructure Biblissima, a large corpus of about 3500 XML files of 15th-c. music. This corpus was produced by the German musicologist Clemens Goldberg who encoded since 2010 onwards the musical content of 34 major 15th-c. music manuscripts and other complementary files, in order to offer on his foundation's website PDF files of complete collections of works by Du Fay, Binchois, Okeghem, Busnoys and most of their major contemporaries, focusing on their secular output. This corpus was encoded in an XML format named CMME (Computerized Mensural Music Editing), specifically conceived for mensural music by Theodor Dumitrescu in the 2000s, together with editorial and publication tools which have not been updated since then. This article focuses on the development of a set of conversion tools for these CMME files to meet more up-to-date standards of music encoding, namely MEI. A workshop was organised in September 2024 at the Campus Condorcet in Paris, gathering experts with a wide range of knowledge on mensural music notation, XML formats and programming. A converter was developped directly in the open-source rendering library Verovio, allowing the conversion from CMME to MEI mensural. A conversion to MEI CMN was implemented afterwards, enabling to load these files in common engraving softwares such as MuseScore with minimal loss of information. With the availability of a direct import of CMME-XML into Verovio, the corpus of existing CMME files gets a new life. Furthermore, since the stand-alone CMME editor still works fine and no alternative is available yet for native MEI, the converter offers a new pipeline for encoding and editing mensural music.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Finkensiep_2025,
-  title = {{An Annotation Interface for Protovoice Analysis}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Finkensiep, Christoph and Rohrmeier, Martin},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {107--111},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/1vkha-t8j47},
-  urldate = {2025-07-08},
-  abstract = {Expert annotations for corpus studies and computational models need to be processable by both humans and computers, which usually requires specialized tools. This paper presents a web-based annotation interface for creating protovoice analyses, a neo-Schenkerian model of hierarchical voice-leading reduction. The interface ensures the consistency of an analysis and supports data export in a machine-readable JSON format as well as visualizations in the form of TikZ/LaTeX and SVG. A separate viewer component can be used to embed interactive visualizations of an analysis in a website. The internal representations and manipulation operations used by the annotation and viewer components is provided by a shared library module which could be also used by other tools to implement extra functionality.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Friedl_2025,
-  title = {{Challenges of Modelling Metadata for Film Music in MEI}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Friedl, Dennis and Reich, Silke},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {116--117},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/tntzq-0e604},
-  urldate = {2025-07-08},
-  abstract = {Erich Wolfgang Korngold (1897--1957) contributions to Hollywood's "golden age" of film music between 1934 and 1946, particularly at Warner Bros., are widely recognised. Beginning with Max Reinhardt's adaptation of Mendelssohn's A Midsummer Night's Dream (1934/35), Korngold became a defining voice in the "Hollywood sound," crafting 19 film scores and winning Academy Awards for Anthony Adverse (1936) and The Adventures of Robin Hood (1939). The Erich Wolfgang Korngold Edition Project seeks to integrate his film music alongside his other compositions in a hybrid scholarly edition. This effort presents significant challenges, requiring the inclusion of traditional written sources (e.g., scores, sketches) and film-specific materials (e.g., scripts, cue sheets, audiovisual content). Such integration demands innovative digital and multimedia formats to account for the unique relationship between music and film. Korngold's film music exemplifies a deep interdependence with its visual counterpart. The bond between music and film is therefore exceptionally close, making the task of modelling this relationship particularly challenging. Within the FRBR framework, the film and its music can be treated as two distinct yet interconnected works. This intricate structure can be represented with all its variations, adaptations, and corresponding digital representations, as well as the relationships linking the two works. Representing this complexity necessitates balancing comprehensive metadata with resource limitations. Using The Adventures of Robin Hood as a case study, this paper examines how metadata standards such as MEI can be applied to represent film music and its intricate connections to film. It explores the suitability and limitations of MEI, considers alternative standards, and reflects on meaningful integrations of metadata for hybrid editions. Rather than presenting definitive solutions, the paper invites discussion on strategies to navigate these challenges in digital musicology.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Garcia-Iasci_2025,
-  title = {{Evaluating Music Encoding Approaches: An Accuracy Analysis of Tools and Standards}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {{Garc{\'i}a-Iasci}, Patricia and Rizo, David and {Calvo-Zaragoza}, Jorge},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {189--194},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/eepkj-etq50},
-  urldate = {2025-07-09},
-  abstract = {This paper considers different approaches for music encoding, evaluating user experience, accessibility, and readability, and accuracy with different software programs which musicologist, researchers, and musicians commonly use. A selection of monophonic pieces from The Dance Music of Ireland have been encoded in PAEC, MEI, MusicXML, and **kern, using manual direct encoding strategies, notation programs, and different OMR procedures. The result allows us to identify the most convenient method according to the needs of each user in each context.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Goebl_2025,
-  title = {{Let's Do the ScoreWarp Again! Shifting Notes to Performance Timelines}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Goebl, Werner and Weigl, David M.},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {49--55},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/gqd3b-w7c28},
-  urldate = {2025-07-08},
-  abstract = {Traditional approaches to visualize performance-related data captured while executing a musical score, rely usually on juxtaposing physical and score-time axes or connecting them with indicators, which can limit cognitive accessibility and interpretive clarity. This paper introduces ScoreWarp, a novel methodology and tool for aligning musical scores with performance timelines by shifting score elements horizontally to correspond with the temporal position of the performance timeline. This approach provides a seamless visual integration of music semantics with empirical timing data, eliminating the need for supplemental piano-roll visualizations or external alignment indicators. Using MEI-encoded scores engraved with the Verovio toolkit and alignment data from MIDI-to-MIDI matching algorithms, ScoreWarp adjusts the placement of individual notes, chords, and associated score elements such as slurs and dynamics. The tool offers two primary warping functions: one aligning chords to single timestamps and another visualizing fine-grained asynchronies at the note level, enabling the depiction of performance nuances like arpeggios or chord asynchronies. This methodology has been implemented in an open-source prototype, enabling users to generate warped SVG scores with physical time axes for integration into broader performance analysis tools. Potential applications include empirical research in music performance, psychology, and listener response, particularly for visualizing physiological and behavioral data in the context of performed music. Future work involves integrating ScoreWarp into comparative performance analysis tools and conducting user studies to evaluate its effectiveness in enhancing interpretive insights across diverse musical and empirical contexts.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Goya_2025,
-  title = {{Exalting Natural Genius: Francesco Geminiani's Pedagogy of Harmonic Creativity}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Goya, Jonathan},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {81--87},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/sm44z-knr59},
-  urldate = {2025-07-08},
-  abstract = {Francesco Geminiani published his Guida Armonica in 1752 with the express aim of liberating students of composition from, in his view, the confining and repetitive harmonic progressions of contemporary compositional pedagogy. The Guida consists of 2236 fragments of figured bass in D minor, each beginning and ending with one of 21 common chords. Complete passages of figured bass thus exist within the Guida network as paths through the common chord nodes and fragment edges. This presentation discusses the historical context of Geminiani's critique and presents a digital implementation of the Guida which facilitates the composition process with digital sort, filter, and edit functions. The implementation also includes an interface to find paths through the Guida network for search queries of bass pitch sequence. The search interface not only supplements the compositional process, but also opens the possibility of using the Guida as a tool for the analysis of 18th-century music. A full movement produced from the Guida fragments demonstrates the utility of the digital implementation and the harmonic variety contained within the Guida. Though the Guida is entirely in the key of D minor and typical 18th-century Rule of the Octave harmonizations of each scale degree are well represented, unusual harmonizations are also offered by the Guida --- often with the strong and weak beats offset compared to the paths using typical harmonizations. These unusual harmonizations reveal secondary key areas implicit in the Guida fragments and the interdependence of key, beat hierarchy, and sonority in the harmonic sensibilities of a well-regarded 18th-century composer and pedagogue.},
+  abstract = {Number-based music notation (NMN) offers an intuitive way to represent music, using numbers to denote pitches. Widely used in Chinese music education, it serves both as an accessible entry point for learners and as a comprehensive system for expressing and conceptualising music. NMN's versatility and adaptability both stem from and are influenced by musical education systems across various cultures, helping students engage with music straightforwardly and effectively. We examine NMN's historical and modern usage in both Eastern and Western contexts, highlighting the extensive adoption of Jianpu in 20th and 21st-century China. We also explore its integration into computer music software, databases, and encodings. We discuss how NMN can represent both simple and complex musical structures, emphasizing its potential for broader incorporation into digital humanities initiatives, including encoding systems such as MEI.},
   keywords = {mec-proceedings, mec-proceedings-2025},
   displayby = {Contributions from MEC 2025}	
 }
@@ -1995,213 +1802,17 @@ The future development of suitable software can facilitate interdisciplinary stu
   displayby = {Contributions from MEC 2025}	
 }
 
-@inproceedings{Jacquemard_2025,
-  title = {{Automated MEI Transcription of a Dataset of Electronic Drum Kit Performances}},
+@inproceedings{Fiala_2025,
+  title = {{A New XML Conversion Process for Mensural Music Encoding : CMME\_to\_MEI (via Verovio)}},
   booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Jacquemard, Florent and {Rodriguez-de la Nava}, Lydia},
+  author = {Fiala, David and Pugin, Laurent and {van Berchum}, Marnix and Thomae, Martha E. and Roger, K{\'e}vin},
   editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
   year = {2025},
-  pages = {70--74},
+  pages = {31--35},
   publisher = {Knowledge Commons},
-  doi = {10.17613/ts2pj-n8q68},
+  doi = {10.17613/gwvsx-q0c26},
   urldate = {2025-07-08},
-  abstract = {We present a method for the automated transcription of human performances on electronic drum kits, captured in MIDI files, into music scores in the MEI encoding. It works by parsing an input MIDI sequence into a tree-structured intermediate representation, using techniques from formal languages and NLP, post-processing the latter representation, with dedicated term rewriting rules, and exporting it into MEI. In an case study conducted on Magenta's Groove MIDI Dataset, we successfully transcribed, without pre-training or manual adjustments, 333 MIDI files of this dataset, covering various genres, time signatures, tempi and of length up to 260 measures.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Jaklin_2025,
-  title = {{Wanted! Approaches for Search in Polyphonic Lute Music}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Jaklin, Julia Maria},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {139--142},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/a1h7s-c6h54},
-  urldate = {2025-07-08},
-  abstract = {Search is one of the key issues in music information retrieval. For symbolically encoded, unvoiced polyphonic music---such as music notated in various types of lute tablatures---this is not an easy task. This poster aims to present the requirements of searching within lute tablatures, present examples of existing methods and approaches, and ask for feedback and further ideas for the development of a search within lute tablatures.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Kepper_2025,
-  title = {{Let's Get Visual. Dealing with Layout Information in MEI}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Kepper, Johannes and Pugin, Laurent},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {66--69},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/hf8kc-beg40},
-  urldate = {2025-07-08},
-  abstract = {This paper addresses the challenges of encoding visual layout information in MEI, which traditionally prioritizes logical structures, such as measures and sections, over visual domains like pages and systems. While this design simplifies logical encoding, it complicates visual representation and limits flexibility for use cases like diplomatic transcriptions. Diplomatic transcriptions require precise encoding of note placement and alignment, which can benefit from separating visual and logical domains into parallel, interlinked encodings. Similarly, Optical Music Recognition (OMR) workflows, which link graphical signs to music symbols, could leverage MEI at multiple stages using facsimile-based solutions, already supported in MEI through and elements. Rendering tools like Verovio could also integrate visual positioning, though challenges remain for complex cases like slurs crossing page breaks. By proposing methods that balance logical and visual perspectives, this paper suggests an adaptable approach for layout-centric use cases, aiming to encourage discussions within the music encoding community to refine MEI's capabilities.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Kijas_2025,
-  title = {{Digital Pedagogy \& Public Musicology Round Table}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Kijas, Anna E. and Grimmer, Jessica and Wissner, Reba and Robin, William},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {214--216},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/jtj6p-atz44},
-  urldate = {2025-07-09},
-  abstract = {Student-centered digital pedagogy and projects enable simultaneous engagement with music history and literature as content while developing expertise in critical digital literacy skills. Through assignments or projects that employ music encoding standards, data curation, or creation of public facing scholarship students develop transferable skills that can be applied beyond the classroom and academy. Their knowledge is made visible through open-access projects that can become a resource for future students or scholars in the form of encoding, mapping, and other novel forms of disseminating information. Furthermore, such publicly available forms of publication aim to be inclusive, projecting knowledge and resources beyond the academy. In this roundtable, we bring together scholars and practitioners with backgrounds in public musicology, digital humanities, libraries, archives, and music encoding who will share their experiences in leveraging digital humanities methods and tools to engage students in experiential praxis-centered music courses and projects. Drawing on experiences teaching a seminar on music and public scholarship, Will Robin will address how to teach students the concept of the public. One longstanding problem of the phrase "public musicology" has been the assumption that there is a single, unified "public" waiting for scholars to reach it; in this presentation, Robin will discuss the idea of publics: how to conceive work aimed towards imagined and real non-academic audiences, and how to help students execute projects that draw on existing publics or develop new ones. As part of the public musicology program at Columbus State University, students take four courses in which they undertake several digital musicology projects including editing and encoding music in manuscript form using MEI, database entry, and use of online digital content management systems for exhibits and archiving. After giving a brief overview of the program, Reba Wissner will discuss how music encoding and digital musicology are fundamental public musicology skills for every music student, and how these skills can be incorporated into almost any music history course. Working with information students presents a unique approach to digital musicology. With an emphasis on creating space for close reading, for preservation, and for generating material that will be useful to future users and researchers, students in a special topics course on Music Encoding at the University of Maryland School of Information encoded a corpus of works by Carrie Jacobs-Bond, based on archival manuscripts at the Library of Congress. They subsequently collaboratively wrote a best practices paper for others embarking on encoding projects. Jessical Grimmer will discuss how this course equips students with technical and conceptual skills in digital humanities fostering connections between scholarly work and public engagement. She will also highlight strategies for using MEI to create accessible, sustainable, and community-focused digital resources.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Klauk_2025,
-  title = {{Visualizing Wagner: A Combined Annotational Approach to Siegfried Act III}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Klauk, Stephanie and Schmolenzky, Pascal and Kleinertz, Rainer and Wei{\ss}, Christof and M{\"u}ller, Meinard},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {184--188},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/x2vba-xn564},
-  urldate = {2025-07-09},
-  abstract = {After the controversial large-scale analyses of Richard Wagner's Der Ring des Nibelungen by Alfred Lorenz, Anthony Newcomb was the first to present new perspectives on large-scale Wagner analysis in 1981. One of his examples was the first scene of the third act of Siegfried. Both Lorenz's and Newcomb's analyses will be evaluated and discussed using visualisations of computational analyses of harmony and tempo based on audio files.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Koester_2025,
-  title = {{The Computational Study of Musical Form: Challenges for Encoding and Analysis}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {K{\"o}ster, Maik and Hentschel, Johannes and Neuwirth, Markus},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {88--96},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/sxjqb-p5r44},
-  urldate = {2025-07-08},
-  abstract = {Form can be viewed as a high-level structural domain of music, which is informed by and interacts with other domains, such as tonal structure, metric structure, repetition structure as well as texture and orchestration. The ways in which the musical parameters influence form and warrant the use of the given analytical terms are, however, rarely made explicit. In our contribution, we assess what is needed to encode analyses of musical form in a way that explicitly models the multi-dimensional interplay between structural domains and emergent formal functions. The needs that this research endeavour poses include support for symbolic as well as audio representations, annotation of timespans as well as events on the note or stave levels, and the ability to bring together different types of analyses, ideally in a user-friendly GUI. A survey of five current annotation tools shows that the desired features are currently dispersed among different apps. We therefore suggest integrating the strengths of different tools using stand-off annotations. The envisioned solution, consisting in combining different annotation apps via the consistent intermediary representation of time, and using a rich uniform ontology, enables the unification of diverse datasets and hence facilitates the study of musical form on a large scale.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Lanz_2025,
-  title = {{Making Computational Study of Gregorian Melody Accessible with ChantLab}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Lanz, Vojt{\v{e}}ch and Szabov{\'a}, Krist{\'i}na and {Haji{\v{c}} jr.}, Jan},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {157--163},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/z50gm-qf714},
-  urldate = {2025-07-08},
-  abstract = {Computational methods for studying Gregorian chant melodies are being developed, but musicologists face technical barriers to applying them, and computer scientists may not have the depth of musicological knowledge required to use them effectively. Part of the [redacted] project's aims is to bridge this gap. To this end, we present ChantLab: a web application for analysing large sets of Gregorian melodies. Specifically, ChantLab implements multiple sequence alignment and phylogenetic tree building, The application visualises the results through an interactive user interface, exports them in widely used formats, and supports custom dataset. ChantLab is available at https://quest.ms.mff.cuni.cz/chantlab},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Lewis_2025,
-  title = {{'Mein Vleis Und Mue': MEI Support for Lute Tablatures}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Lewis, David and Janju{\v{s}}, Olja and {de Valk}, Reinier and Weigl, David M. and Crawford, Tim and Overell, Paul and Sch{\"o}ning, Kateryna},
-  editor = {Lewis, David and Stremel, Sophie and Plaksin, Anna},
-  year = {2025},
-  pages = {75--80},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/f5xjr-jj674},
-  urldate = {2025-07-08},
-  abstract = {Tablatures differ from other music notation types in that they do not describe abstract music semantics directly, but rather prescribe actions for the musician(s) performing the music. Though tablature notations exist for many instruments (e.g. keyboards and accordions), it has central importance for plucked-string instruments such as the lute (from the late 15th to the 18th century) and guitar (particularly in popular music of the 20th century). We are pleased to announce the inclusion of plucked string tablatures into MEI 5.1, with a particular focus on historical notation for the lute and related instruments. In our paper, we describe the community process that has given rise to this, the changes to the schema and guidelines, and the tooling that supports working with tablature in MEI.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Mantica_2025,
-  title = {{Towards a Digital Critical Edition of the Operas of Vincenzo Bellini}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Mantica, Candida Billie and Meriani, Giovanni and Saccomano, Mark Scott and Maccarini, Francesco},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {201--205},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/2qn07-r6523},
-  urldate = {2025-07-09},
-  abstract = {Established in 2003, the Edizione critica delle opere di Vincenzo Bellini (Milan, Ricordi) plans to publish all of Bellini's music in a critical edition, serving a dual purpose: philological, to render musical texts that reflect authorial intention; and practical, to provide users and performers with reliable scores that correct errors perpetuated by traditional editions. Its traditional printed book format presents, however, several practical limitations: a) it does not allow simultaneous visualization of alternative materials; b) users lack access to the sources on which the volumes are based; c) the text of the main score cannot be modified, preventing the use of alternative materials. This poster illustrates the research objectives of the NextGenerationEU-funded project VerDigital (University of Pavia), which intends to overcome these limitations by combining the meticulous editorial approach of the series with tools offered by digital musicology. Specifically, VerDigital will employ the Edirom digital tools and Verovio to develop two interconnected models. 1) A model of digital critical edition using Bellini's "Adelson e Salvini" as a case study. The model does not simply provide encodings (MEI) of the individual sources, which do not allow for the reconstruction of a complete edited text that can be used by performers. Instead, it also presents an encoding of the edited text, offering data to retrace the editorial process. Relying on a tailored combination of Edirom, MEI and Verovio, the model develops an interactive system of fruition, allowing performers to choose among alternative readings/versions to customize their score/parts. 2) The second model focuses on Bellini's so-called 'studi giornalieri', attesting the first phases of his creative process. The model aims at connecting two different encodings: a 'diplomatic-interpretive' one, based on the actual spatial organization of the annotations in the pages, and another 'linearized' transcription, centered on the textual features of every fragment.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Nachtwey_2025,
-  title = {{Beyond Bars: Distribution of Differences in Music Prints}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Nachtwey, Adrian and Moss, Fabian C.},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {136--138},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/8cw62-5mt26},
-  urldate = {2025-07-08},
-  abstract = {Our goal is to analyse differences between prints of Beethoven's Piano Sonatas. Since there is a huge number of prints, we will only compare sample encodings instead of full encodings. The aim of the presented work is to evaluate three different algorithms to draw these samples and find the one which draws the samples that best represent the prints. To that end we used six editions of Beethoven's Bagatelles Op. 33 as a test group and drew 1000 samples from each Bagatelle for each algorithm. Then, encodings of these samples were compared, resulting in 45.000 comparisons for each Bagatelle. To visualize the results, they are being plotted, so that the number of differences can be seen on the x-axis and the frequency, with which this number of differences occurs, on the y-axis. As a result we obtain a normal distribution for each of the algorithms but with different scale parameters. We interpret this finding to demonstrate that thinking of music in terms of bars is not sufficient to find a sample that represents the basic population. Instead, it is necessary to take into account the density of the musical events in the scores.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Neumann_2025,
-  title = {{Building an Interpretations-Edition}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Neumann, Joshua},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {56--60},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/s1t13-r3z56},
-  urldate = {2025-07-08},
-  abstract = {Digital editions of music represent the fusion of musicology's longstanding focus on philological questions with the affordances of technological flexibility for data modelling, encoding, and presentation, along with possibilities for rapid and broad dissemination. Parallel to analogue musicological work, the focus remains on the concept of works and the identification and compilation of authoritative or definitive editions. Notably absent in both spheres are the contributions of performers and the acknowledgment that music is foremost a sounded entity rather than only a written one. Of course, exponentially more challenges exist for documenting the process of performance than the fixity of a written score. A first step in the direction of addressing some of these challenges still lies within the area of philology, albeit with a different purpose than has been conventional: an Interpretations Edition. Here, the goal is to account for diverse interpretive instructions appearing in a variety of score editions. In the case of project design, of course, a primary challenge is how to balance the usual plethora of editions against a corpus of recordings for interpretations-analysis. Curating the edition to the specific needs of a project thus becomes of paramount importance. More than exhibiting the conceptual variations in the use of MEI for this kind of work, this paper reinforces the importance of balancing technological development with the best ethical practices of edition making as historiographical praxis.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Obert_2025,
-  title = {{Sketching Genetic Editions: Challenges and Opportunities}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Obert, Salome and Seipelt, Agnes and Paciotti, Alessandra and Raunisi, Cecilia and Rosendahl, Lisa},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {208--213},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/ryvf1-y3w06},
-  urldate = {2025-07-09},
-  abstract = {The digital humanities have been changing scholarly methodologies in musicology for quite a while now. With this panel we would like to explore the possibilities of musicological genetic editions also in the digital realm. Bringing together four doctoral students with different backgrounds, experts on various 19th century composers, the discussion aims to address critical questions about the nature, scope, and practical implementation of genetic criticism into digital editions. Our focus extends beyond the territory of the well known project Beethovens Werkstatt, examining how new approaches can accommodate a wide array of musical repertoires, sources, and creative processes. Each panelist will pitch their research, highlighting the unique selling points of their projects, the challenges posed by their sources, and the innovative models, tools and concepts used to address these challenges. The panel is organized around four case studies: the sketches and autograph manuscript for Beethoven's Bagatelle Op. 126, Franz Liszt's autograph manuscript for the Sonata in B minor, the preparatory materials for Carl Maria von Weber's opera Die drei Pintos, and the surviving compositional sketches of Johannes Brahms. Collectively, these studies offer a multifaceted view of how digital genetic editions can address diverse repertoires and reveal the creative dynamics embedded in musical documents. Digital genetic editions represent an attempt to document and analyze the creative process of composition through a dynamic representation of its textual and musical sources. These editions seek to move beyond the final stage of the work by shedding light on the intermediary stages of creation. Beethovens Werkstatt -- a joint research project by the Beethoven-Haus Bonn (Germany) and the Department of Musicology Detmold/Paderborn (Germany), funded by the Academy of Sciences and Literature Mainz (Germany) -- plays a pioneering role in the field of genetic text criticism in music and digital editions. It is a fundamental research project that, for the first time, presents a series of concepts and models, as well as a glossary, for the investigation of writing and compositional processes in music and their digital representation and communication. Each panelist will introduce a case study, illustrating how their project expands the boundaries of genetic editions and illustrates the extent to which the research subject could reuse the concepts and (data) models from Beethovens Werkstatt and where there is a need to modify or extend them. The case studies expand the focus beyond a single composer's workshop, addressing different genres/repertoires and creative contexts. They invite comparisons and contrasts, offering insights into how the lessons of Beethovens Werkstatt can be adapted to different challenges, from Liszt's fluid revisions to the openness of the Weber manuscript. The presented sources reveal distinct challenges and possibilities for genetic editions, also in digital form. By focusing on these themes, the panel aims to inspire a broader conversation about the future of digital genetic editions in musicology. Ultimately, this panel envisions a future where digital genetic editions become a central tool for understanding and engaging with the creative processes of composers.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Page_2025,
-  title = {{Annotating Music Scores: Representing and Interacting with Annotations with MEI and Verovio}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Page, Kevin R. and Pugin, Laurent and Weigl, David M.},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {222--225},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/8q6rc-es750},
-  urldate = {2025-07-09},
-  abstract = {This half-day workshop will address annotations of musical scores, considering their role and structure, and strategies for representing, encoding and visualising them. The workshop will combine presentations, discussion and hands-on activities with new versions of Verovio and mei-friend. Annotation is an activity common across many walks of life and, for music, it unites scholars, musicians, teachers and composers. The practice is extremely varied, both in the forms it takes and the purposes it serves, and it is used for both physical and digital material. Digital annotations refer to highlights, circles, references, links or other selections made on digital documents or media. User-generated annotations are increasingly seen as a key mechanism for the use and reuse of digital materials across a wide range of applications, while also enhancing the findability and accessibility of that media through its annotations. While the importance of annotations in music notation is generally acknowledged, there is less of a consensus on how best to integrate them into interoperable software applications. Annotations for music can encompass the association of textual observations with regions of a work; cross-reference between musical passages or from a musical passage to some other, non-musical, material; or they might include categorical or structured music-analytical annotations, such as metrical or harmonic labels; most commonly, perhaps, they are used by musicians and teachers for sharing or remembering aspects of musical interpretation. Approaches taken in the digital domain include graphical, drawn overlays on top of an engraved score (which is popular in software for musicians and teachers), the use of URLs to specify score regions to be extracted and drawn by a web service (EMA, used by the CRIM project), Web Annotations (a Linked Data standard used by the MELD framework) and the MEI element itself. Given this diversity, it is essential to align implementation to specific needs and use cases rather than assuming a universal solution. This workshop consolidates a review of existing digital score annotation implementations, presenting new recommendations for enhanced annotation practice in MEI, and with hands-on experiments for implementing these recommendations in Verovio and mei-friend.},
-  bibbase_note = {<span style="color: green; font-weight: bold">Workshop.</span>},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Peter_2025,
-  title = {{How to Infer Repeat Structures in MIDI Performances}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Peter, Silvan David and Hu, Patricia and Widmer, Gerhard},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {173--177},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/vbe6s-rds89},
-  urldate = {2025-07-09},
-  abstract = {MIDI performances are generally expedient in performance research and music information retrieval, and even more so if they can be connected to a score (Cancino-Chac{\'o}n et al., 2018, Peter et al., 2023). This connection is usually established by means of alignment, linking either notes or time points between the score and the performance. The first obstacle when trying to establish such an alignment is that a performance realizes one (out of many) structural versions of the score that can plausibly result from instructions such as repeats, variations, and navigation markers like 'dal segno/da capo al coda'. A score needs to be unfolded, that is, its repeats and navigation markers need to be explicitly written out to create a single timeline without jumps matching the performance, before alignment algorithms can be applied. In the curation of large performance corpora this process is carried out manually, as no tools are available to infer the repeat structure of the performance (Bukey et al., 2024). To ease this process, we develop a method to automatically infer the repeat structure of a MIDI performance, given a symbolically encoded score including repeat and navigation markers. The intuition guiding our design is: 1) local alignment of every contiguous section of the score with a section of a performance containing the same material should receive low alignment cost, whereas local alignment with any other performance section should accrue a high cost. And 2) stitching local alignments together according to a valid structural version of the score should result in an approximate full alignment and correspondingly low global backtracking cost if the structural version corresponds to the performance, and high cost for all other, ill-fitting structural versions.},
+  abstract = {The Ricercar Lab --- the musicological research team at the Center for advanced Studies in the Renaissance at the University of Tours --- has decided to make available in open access, thanks to the support of the French digital infrastructure Biblissima, a large corpus of about 3500 XML files of 15th-c. music. This corpus was produced by the German musicologist Clemens Goldberg who encoded since 2010 onwards the musical content of 34 major 15th-c. music manuscripts and other complementary files, in order to offer on his foundation's website PDF files of complete collections of works by Du Fay, Binchois, Okeghem, Busnoys and most of their major contemporaries, focusing on their secular output. This corpus was encoded in an XML format named CMME (Computerized Mensural Music Editing), specifically conceived for mensural music by Theodor Dumitrescu in the 2000s, together with editorial and publication tools which have not been updated since then. This article focuses on the development of a set of conversion tools for these CMME files to meet more up-to-date standards of music encoding, namely MEI. A workshop was organised in September 2024 at the Campus Condorcet in Paris, gathering experts with a wide range of knowledge on mensural music notation, XML formats and programming. A converter was developped directly in the open-source rendering library Verovio, allowing the conversion from CMME to MEI mensural. A conversion to MEI CMN was implemented afterwards, enabling to load these files in common engraving softwares such as MuseScore with minimal loss of information. With the availability of a direct import of CMME-XML into Verovio, the corpus of existing CMME files gets a new life. Furthermore, since the stand-alone CMME editor still works fine and no alternative is available yet for native MEI, the converter offers a new pipeline for encoding and editing mensural music.},
   keywords = {mec-proceedings, mec-proceedings-2025},
   displayby = {Contributions from MEC 2025}	
 }
@@ -2221,6 +1832,129 @@ The future development of suitable software can facilitate interdisciplinary stu
   displayby = {Contributions from MEC 2025}	
 }
 
+@inproceedings{Goebl_2025,
+  title = {{Let's Do the ScoreWarp Again! Shifting Notes to Performance Timelines}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Goebl, Werner and {M. Weigl}, David},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {49--55},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/gqd3b-w7c28},
+  urldate = {2025-07-08},
+  abstract = {Traditional approaches to visualize performance-related data captured while executing a musical score, rely usually on juxtaposing physical and score-time axes or connecting them with indicators, which can limit cognitive accessibility and interpretive clarity. This paper introduces ScoreWarp, a novel methodology and tool for aligning musical scores with performance timelines by shifting score elements horizontally to correspond with the temporal position of the performance timeline. This approach provides a seamless visual integration of music semantics with empirical timing data, eliminating the need for supplemental piano-roll visualizations or external alignment indicators. Using MEI-encoded scores engraved with the Verovio toolkit and alignment data from MIDI-to-MIDI matching algorithms, ScoreWarp adjusts the placement of individual notes, chords, and associated score elements such as slurs and dynamics. The tool offers two primary warping functions: one aligning chords to single timestamps and another visualizing fine-grained asynchronies at the note level, enabling the depiction of performance nuances like arpeggios or chord asynchronies. This methodology has been implemented in an open-source prototype, enabling users to generate warped SVG scores with physical time axes for integration into broader performance analysis tools. Potential applications include empirical research in music performance, psychology, and listener response, particularly for visualizing physiological and behavioral data in the context of performed music. Future work involves integrating ScoreWarp into comparative performance analysis tools and conducting user studies to evaluate its effectiveness in enhancing interpretive insights across diverse musical and empirical contexts.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Neumann_2025,
+  title = {{Building an Interpretations-Edition}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Neumann, Joshua},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {56--60},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/s1t13-r3z56},
+  urldate = {2025-07-08},
+  abstract = {Digital editions of music represent the fusion of musicology's longstanding focus on philological questions with the affordances of technological flexibility for data modelling, encoding, and presentation, along with possibilities for rapid and broad dissemination. Parallel to analogue musicological work, the focus remains on the concept of works and the identification and compilation of authoritative or definitive editions. Notably absent in both spheres are the contributions of performers and the acknowledgment that music is foremost a sounded entity rather than only a written one. Of course, exponentially more challenges exist for documenting the process of performance than the fixity of a written score. A first step in the direction of addressing some of these challenges still lies within the area of philology, albeit with a different purpose than has been conventional: an Interpretations Edition. Here, the goal is to account for diverse interpretive instructions appearing in a variety of score editions. In the case of project design, of course, a primary challenge is how to balance the usual plethora of editions against a corpus of recordings for interpretations-analysis. Curating the edition to the specific needs of a project thus becomes of paramount importance. More than exhibiting the conceptual variations in the use of MEI for this kind of work, this paper reinforces the importance of balancing technological development with the best ethical practices of edition making as historiographical praxis.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Cividini_2025,
+  title = {{Switching Between Standard and Original Score Order: Encoding, Transforming and Rendering Alternative Score Definitions in Digital Music Editions}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Cividini, Iacopo and {Mair-Gruber}, Roland and {Sapov-Erlinger}, Oleksii},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {61--65},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/n7h15-jtq15},
+  urldate = {2025-07-08},
+  abstract = {Printed music editions face a critical dilemma in the definition of the score order. On the one hand, the standard score order established in the 20th century offers several practical advantages: it allows for a more compact score by grouping individual parts on a single staff, and it provides a convention that is broadly accepted and used for editions of works from all historical periods. On the other hand, the standard score order often differs significantly from the original parts arrangement chosen by the composer. As a result, it may overlook important aspects of the compositional process and the composer's intention in structuring the score in a particular way. Furthermore, the standard score order may no longer reflect the historical ensemble configuration originally intended by the composer, which could affect the performance interpretation of the work. For these reasons, some printed music editions have restored the original order of the scores. Using Mozart's Exsultate, jubilate KV 165 as a case study, the paper discusses a solution to the editorial dilemma in a digital edition by offering the option to choose between alternative score configurations. By encoding each part of a score in MEI as a semantically independent layer, each part can be relocated into alternative score configurations using a dedicated transformation tool. As a result, the MEI file, originally encoded in one score order, can potentially be displayed in any other score order. This finally enables switching between the standard and the original score order in a web application.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Kepper_2025,
+  title = {{Let's Get Visual. Dealing with Layout Information in MEI}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Kepper, Johannes and Pugin, Laurent},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {66--69},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/hf8kc-beg40},
+  urldate = {2025-07-08},
+  abstract = {This paper addresses the challenges of encoding visual layout information in MEI, which traditionally prioritizes logical structures, such as measures and sections, over visual domains like pages and systems. While this design simplifies logical encoding, it complicates visual representation and limits flexibility for use cases like diplomatic transcriptions. Diplomatic transcriptions require precise encoding of note placement and alignment, which can benefit from separating visual and logical domains into parallel, interlinked encodings. Similarly, Optical Music Recognition (OMR) workflows, which link graphical signs to music symbols, could leverage MEI at multiple stages using facsimile-based solutions, already supported in MEI through and elements. Rendering tools like Verovio could also integrate visual positioning, though challenges remain for complex cases like slurs crossing page breaks. By proposing methods that balance logical and visual perspectives, this paper suggests an adaptable approach for layout-centric use cases, aiming to encourage discussions within the music encoding community to refine MEI's capabilities.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Jacquemard_2025,
+  title = {{Automated MEI Transcription of a Dataset of Electronic Drum Kit Recordings}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Jacquemard, Florent and {Rodriguez-de la Nava}, Lydia},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {70--74},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/ts2pj-n8q68},
+  urldate = {2025-07-08},
+  abstract = {We present a method for the automated transcription of human performances on electronic drum kits, captured in MIDI files, into music scores in the MEI encoding. It works by parsing an input MIDI sequence into a tree-structured intermediate representation, using techniques from formal languages and NLP, post-processing the latter representation, with dedicated term rewriting rules, and exporting it into MEI. In an case study conducted on Magenta's Groove MIDI Dataset, we successfully transcribed, without pre-training or manual adjustments, 333 MIDI files of this dataset, covering various genres, time signatures, tempi and of length up to 260 measures.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Lewis_2025,
+  title = {{'Mein vleis und mue': MEI Support for Lute Tablatures}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Lewis, David and Janju{\v{s}}, Olja and {de Valk}, Reinier and {M. Weigl}, David and Crawford, Tim and Overell, Paul and Sch{\"o}ning, Kateryna},
+  editor = {Lewis, David and Stremel, Sophie and Plaksin, Anna},
+  year = {2025},
+  pages = {75--80},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/f5xjr-jj674},
+  urldate = {2025-07-08},
+  abstract = {Tablatures differ from other music notation types in that they do not describe abstract music semantics directly, but rather prescribe actions for the musician(s) performing the music. Though tablature notations exist for many instruments (e.g. keyboards and accordions), it has central importance for plucked-string instruments such as the lute (from the late 15th to the 18th century) and guitar (particularly in popular music of the 20th century). We are pleased to announce the inclusion of plucked string tablatures into MEI 5.1, with a particular focus on historical notation for the lute and related instruments. In our paper, we describe the community process that has given rise to this, the changes to the schema and guidelines, and the tooling that supports working with tablature in MEI.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Goya_2025,
+  title = {{\textit{Exalting Natural Genius}: Francesco Geminiani's Pedagogy of Harmonic Creativity}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Goya, Jonathan},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {81--87},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/sm44z-knr59},
+  urldate = {2025-07-08},
+  abstract = {Francesco Geminiani published his Guida Armonica in 1752 with the express aim of liberating students of composition from, in his view, the confining and repetitive harmonic progressions of contemporary compositional pedagogy. The Guida consists of 2236 fragments of figured bass in D minor, each beginning and ending with one of 21 common chords. Complete passages of figured bass thus exist within the Guida network as paths through the common chord nodes and fragment edges. This presentation discusses the historical context of Geminiani's critique and presents a digital implementation of the Guida which facilitates the composition process with digital sort, filter, and edit functions. The implementation also includes an interface to find paths through the Guida network for search queries of bass pitch sequence. The search interface not only supplements the compositional process, but also opens the possibility of using the Guida as a tool for the analysis of 18th-century music. A full movement produced from the Guida fragments demonstrates the utility of the digital implementation and the harmonic variety contained within the Guida. Though the Guida is entirely in the key of D minor and typical 18th-century Rule of the Octave harmonizations of each scale degree are well represented, unusual harmonizations are also offered by the Guida --- often with the strong and weak beats offset compared to the paths using typical harmonizations. These unusual harmonizations reveal secondary key areas implicit in the Guida fragments and the interdependence of key, beat hierarchy, and sonority in the harmonic sensibilities of a well-regarded 18th-century composer and pedagogue.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Koester_2025,
+  title = {{The Computational Study of Musical Form: Challenges for Encoding and Analysis}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {K{\"o}ster, Maik and Hentschel, Johannes and Neuwirth, Markus},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {88--95},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/sxjqb-p5r44},
+  urldate = {2025-07-08},
+  abstract = {Form can be viewed as a high-level structural domain of music, which is informed by and interacts with other domains, such as tonal structure, metric structure, repetition structure as well as texture and orchestration. The ways in which the musical parameters influence form and warrant the use of the given analytical terms are, however, rarely made explicit. In our contribution, we assess what is needed to encode analyses of musical form in a way that explicitly models the multi-dimensional interplay between structural domains and emergent formal functions. The needs that this research endeavour poses include support for symbolic as well as audio representations, annotation of timespans as well as events on the note or stave levels, and the ability to bring together different types of analyses, ideally in a user-friendly GUI. A survey of five current annotation tools shows that the desired features are currently dispersed among different apps. We therefore suggest integrating the strengths of different tools using stand-off annotations. The envisioned solution, consisting in combining different annotation apps via the consistent intermediary representation of time, and using a rich uniform ontology, enables the unification of diverse datasets and hence facilitates the study of musical form on a large scale.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+%%% -------------------------------
+%%% MEC 2025 Proceedings: Short Papers
+
 @inproceedings{Pineo_2025,
   title = {{Using MEI to Create Accessible Music Scores: Findings from a Pilot Study}},
   booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
@@ -2236,6 +1970,159 @@ The future development of suitable software can facilitate interdisciplinary stu
   displayby = {Contributions from MEC 2025}	
 }
 
+@inproceedings{Stickler_2025,
+  title = {{A Minimal Publishing Model for Text and Music Notation}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Stickler, Felicitas and Roeder, Torsten and Moss, Fabian C.},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {104--106},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/fv740-yvf93},
+  urldate = {2025-07-08},
+  abstract = {This paper introduces a minimal publishing model tailored for digital editions that incorporate both text and music notation. While established encoding standards like TEI and MEI are well-suited for text or music individually, their integration poses significant challenges for interdisciplinary projects such as music theory treatises, composers' correspondence, and sheet music editions with peritexts. To address these issues, we propose a sustainable approach using Verovio and CeTEIcean for dynamic rendering, emphasizing direct data generation without intermediate formats. The proposed model simplifies data organization, synchronizes rendering processes, and ensures low-cost deployment through platforms like GitHub Pages and Zenodo. This method not only supports resource-constrained projects but also serves as a blueprint for the TEI Music SIG to harmonize text and music encoding. The approach will be implemented in the Digitizing the Dualism Debate project, aiming to enrich the presentation of dense text-music relationships and lay the groundwork for future digital editions of hybrid materials.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Finkensiep_2025,
+  title = {{An Annotation Interface for Protovoice Analysis}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Finkensiep, Christoph and Rohrmeier, Martin},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {107--111},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/1vkha-t8j47},
+  urldate = {2025-07-08},
+  abstract = {Expert annotations for corpus studies and computational models need to be processable by both humans and computers, which usually requires specialized tools. This paper presents a web-based annotation interface for creating protovoice analyses, a neo-Schenkerian model of hierarchical voice-leading reduction. The interface ensures the consistency of an analysis and supports data export in a machine-readable JSON format as well as visualizations in the form of TikZ/LaTeX and SVG. A separate viewer component can be used to embed interactive visualizations of an analysis in a website. The internal representations and manipulation operations used by the annotation and viewer components is provided by a shared library module which could be also used by other tools to implement extra functionality.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Desmond_2025,
+  title = {{The Encoding of Insular Polyphony in English Mensural and Pre-mensural Notations}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Desmond, Karen},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {112--115},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/2zcma-hb133},
+  urldate = {2025-07-08},
+  abstract = {The Music Encoding Initiative currently has two fairly robust modules for the encoding of vocal repertoire notated in important medieval notation systems, namely the MEI Neumes module (for plainchant) and the MEI Mensural Notation module (for polyphony). Franco's systematic rule-based system for mensural notation made a significant intervention in the history of music when he asserted that the notational symbol (the 'figure') ought to represent a fixed duration. But a significant portion of the western European polyphonic repertoire is notated in notations that preceded Franco's rule-based system that associated fixed durations to specific symbols, including, for example, the Aquitanian and Parisian polyphonic repertoires. BROKENSONG, a five-year project funded by an ERC Consolidator Grant, examines polyphonic singing and written culture in late medieval Britain and Ireland, from c. 1150-c. 1350. As part of the project, the entire extant repertoire is being encoded (approximately 600 compositions, many of them fragmentary, notated in approximately 120 fragmentary manuscript sources). While many compositions are notated in Franconian and extended Franconian notations, a large portion of the repertoire is notated in notations that can be broadly categorized as either modal, modal with Insular characteristics, and pre-mensural or mensural with Insular characteristics (Bent, Wibberley, Lefferts, Losseff). These notations are more flexible than standard Franconian notation and frequently informed by local practice. The interpretation may be dependent on notational dialects used in a particular geographic location, or by a particular scribe, or indeed the interpretation may be unclear. In this paper, I introduce two case studies from the BROKENSONG repertoire copied in Insular notation and present some of the most significant issues related to their encoding.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Friedl_2025,
+  title = {{Challenges of Modelling Metadata for Film Music in MEI}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Friedl, Dennis and Reich, Silke},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {116--117},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/tntzq-0e604},
+  urldate = {2025-07-08},
+  abstract = {Erich Wolfgang Korngold (1897--1957) contributions to Hollywood's "golden age" of film music between 1934 and 1946, particularly at Warner Bros., are widely recognised. Beginning with Max Reinhardt's adaptation of Mendelssohn's A Midsummer Night's Dream (1934/35), Korngold became a defining voice in the "Hollywood sound," crafting 19 film scores and winning Academy Awards for Anthony Adverse (1936) and The Adventures of Robin Hood (1939). The Erich Wolfgang Korngold Edition Project seeks to integrate his film music alongside his other compositions in a hybrid scholarly edition. This effort presents significant challenges, requiring the inclusion of traditional written sources (e.g., scores, sketches) and film-specific materials (e.g., scripts, cue sheets, audiovisual content). Such integration demands innovative digital and multimedia formats to account for the unique relationship between music and film. Korngold's film music exemplifies a deep interdependence with its visual counterpart. The bond between music and film is therefore exceptionally close, making the task of modelling this relationship particularly challenging. Within the FRBR framework, the film and its music can be treated as two distinct yet interconnected works. This intricate structure can be represented with all its variations, adaptations, and corresponding digital representations, as well as the relationships linking the two works. Representing this complexity necessitates balancing comprehensive metadata with resource limitations. Using The Adventures of Robin Hood as a case study, this paper examines how metadata standards such as MEI can be applied to represent film music and its intricate connections to film. It explores the suitability and limitations of MEI, considers alternative standards, and reflects on meaningful integrations of metadata for hybrid editions. Rather than presenting definitive solutions, the paper invites discussion on strategies to navigate these challenges in digital musicology.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Einbond_2025,
+  title = {{Encoding Interactive, Immersive, and Generative Electroacoustic Music}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Einbond, Aaron},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {118--123},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/ee60x-jd298},
+  urldate = {2025-07-08},
+  abstract = {This short paper is presented as an invitation to explore the challenges of encoding music for instruments and interactive electronics including elements of immersive 3-D sound and generative computer improvisation. The topic of encoding electronic music has been addressed in the context of fixed media (Zwi{\ss}ler et al., 2021) but interactive electronics present specific challenges: it may involve acoustic instruments accompanied by computer, and both of these may vary from performance to performance due to human and computer improvisation. Further, the notation of the electronic part may follow different strategies from that of the acoustic instruments, including timbral and spatial information that can be specified using audio descriptors and higher order Ambisonics (HOA). A work for solo percussion and interactive 3-D electronics is presented as a case study to highlight these challenges.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+%%% -------------------------------
+%%% MEC 2025 Proceedings: Posters
+
+@inproceedings{Bonde_2025,
+  title = {Enhancing the Experience of Contemporary Classical Music through Dynamic, Interactive Visualisation},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Bonde, Anders and Meredith, David},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {127--131},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/5qj0w-jsn47},
+  urldate = {2025-07-08},
+  abstract = {We explore the problem of designing dynamic, interactive visualisations in order to enhance the experience of contemporary classical music. We aim to address the well-recognized problem that contemporary classical music (CCM) receives minimal media attention and lacks prominent dissemination in mainstream culture. Recent empirical studies (Emerson, 2020) have suggested that adding appropriate extra-musical and audiovisual elements to a CCM performance can attract newcomers to this type of music and enhance audience experience. We identify four dilemmas that emerge when designing an effective visualisation, specifically, that a visualisation should (1) enhance the experience without distracting listeners from the music itself; (2) guide listeners through the music without constraining their interpretation; (3) possibly provide listeners with the option to control their experience, subject to the user interface being self-explanatory and only to the extent that this does not distract attention from the music; and (4) provide listeners with a means to locate themselves within the music, but without disclosing the music's development prematurely.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Arjmand_2025,
+  title = {{A Step Forward in Lute Tablature Studies with \textit{MEI.Tablature}}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Arjmand, Ailin and Seyedi, Reza},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {132--135},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/frpq3-ytw66},
+  urldate = {2025-07-08},
+  abstract = {The Tablatures from the Albani Collection project, a collaboration between the Ricercar Lab at the Centre d'{\'E}tudes Sup{\'e}rieures de la Renaissance (Tours, France) and the Ente Olivieri in Pesaro (Italy), focuses on the rediscovered Albani archives: a collection of 38 music manuscripts containing lute music from the late Renaissance and early Baroque periods. By adopting the MEI.tablature module, the project encodes musical incipits, enriches them with detailed metadata, and integrates the results into the Ricercar database, making these valuable resources openly accessible through a IIIF viewer. The initiative tackles significant challenges related to MEI.tablature, including its limitations for early lute notation and the constraints of existing tools like Verovio, MuseScore, and Luteconv. To address these issues, the project introduces R{\'e}Tab, a web-based application designed to simplify and enhance the encoding of lute tablature. R{\'e}Tab offers a streamlined, customizable workflow, ensures synchronization between visualized tablature and MEI code, and accommodates historical notational practices. This project represents a notable advancement in digital musicology, contributing to the refinement of MEI.tablature and fostering broader adoption of standardized tools for music encoding. By providing open-access resources and innovative solutions, it paves the way for future research and digital dissemination of Renaissance musical heritage.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Nachtwey_2025,
+  title = {{Beyond Bars: Distribution of Differences in Music Prints}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Nachtwey, Adrian and Moss, Fabian C.},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {136--138},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/8cw62-5mt26},
+  urldate = {2025-07-08},
+  abstract = {Our goal is to analyse differences between prints of Beethoven's Piano Sonatas. Since there is a huge number of prints, we will only compare sample encodings instead of full encodings. The aim of the presented work is to evaluate three different algorithms to draw these samples and find the one which draws the samples that best represent the prints. To that end we used six editions of Beethoven's Bagatelles Op. 33 as a test group and drew 1000 samples from each Bagatelle for each algorithm. Then, encodings of these samples were compared, resulting in 45.000 comparisons for each Bagatelle. To visualize the results, they are being plotted, so that the number of differences can be seen on the x-axis and the frequency, with which this number of differences occurs, on the y-axis. As a result we obtain a normal distribution for each of the algorithms but with different scale parameters. We interpret this finding to demonstrate that thinking of music in terms of bars is not sufficient to find a sample that represents the basic population. Instead, it is necessary to take into account the density of the musical events in the scores.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Jaklin_2025,
+  title = {{Wanted! Approaches for Search in Polyphonic Lute Music}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Jaklin, Julia Maria},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {139--142},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/a1h7s-c6h54},
+  urldate = {2025-07-08},
+  abstract = {Search is one of the key issues in music information retrieval. For symbolically encoded, unvoiced polyphonic music---such as music notated in various types of lute tablatures---this is not an easy task. This poster aims to present the requirements of searching within lute tablatures, present examples of existing methods and approaches, and ask for feedback and further ideas for the development of a search within lute tablatures.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Dvorakova_2025,
+  title = {{Visualizing Gregorian Traditions: ChantMapper}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Dvo{\v{r}}{\'a}kov{\'a}, Anna and {Haji{\v{c}} jr.}, Jan},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {143--151},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/g378z-ppk48},
+  urldate = {2025-07-08},
+  abstract = {One of the major topics in Gregorian chant scholarship is the study of chant transmission and traditions: systematizing the variability of chant repertoire witnessed in sources across medieval Europe. Given that several hundred chant sources have been digitally catalogued, there is a clear opportunity for computational methods, but in the absence of ground truth against which to measure their accuracy, manual inspection of results by experts remains necessary. This in turn requires appropriate user interfaces for visualizing the results. Given that locations -- or transregionality -- are part of what defines the identity of a chant tradition, we believe this interface should involve a map. Hence, we present ChantMapper: a pilot web application for computational analysis of chant repertoire on a map. The interface can be used both to analyse traditions found by known methods (exemplified by Louvain community detection), as well as to inspect results of proposed methods (e.g. topic models). While the application provides a large dataset of antiphons and responsories extracted via Cantus Index and enriched with geocoding information users can upload their own datasets as well.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
 @inproceedings{Polyakov_2025,
   title = {{Encoding the New Frontier: Adapting MEI and Verovio for Post-Tonal and Spectral Notations}},
   booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
@@ -2247,6 +2134,126 @@ The future development of suitable software can facilitate interdisciplinary stu
   doi = {10.17613/exk9y-s3x74},
   urldate = {2025-07-08},
   abstract = {This paper examines the challenges and strategies involved in encoding post-tonal and spectral musical notations within the Music Encoding Initiative (MEI) format for rendering with the Verovio library. While Verovio has become a streamlined and efficient tool for displaying standard music notation, its application to contemporary scores featuring microtonality and non-traditional symbolic elements presents significant hurdles. This proposal introduces AudioSpylt, a Python-based toolset leveraging Verovio to visualize pitch structures derived from audio analysis. AudioSpylt employs MEI in unconventional ways to represent data exceeding the limitations of standard notation, approximating complex elements found in environments like OpenMusic. By critically assessing these "hacks" for encoding microtonal pitch data and graphic notations within a Python/Jupyter environment, this paper highlights both the practical benefits of such approaches for specialized research and the inherent limitations of current standards. The increasing prevalence of publicly available microtonal and spectral scores necessitates a broader discussion about expanding MEI's capabilities. This paper advocates for a more inclusive and robust encoding environment within MEI and Verovio to facilitate the accurate representation and analysis of the full spectrum of contemporary musical practices.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Lanz_2025,
+  title = {{Making Computational Study of Gregorian Melody Accessible with ChantLab}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Lanz, Vojt{\v{e}}ch and Szabov{\'a}, Krist{\'i}na and {Haji{\v{c}} jr.}, Jan},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {157--163},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/z50gm-qf714},
+  urldate = {2025-07-08},
+  abstract = {Computational methods for studying Gregorian chant melodies are being developed, but musicologists face technical barriers to applying them, and computer scientists may not have the depth of musicological knowledge required to use them effectively. Part of the [redacted] project's aims is to bridge this gap. To this end, we present ChantLab: a web application for analysing large sets of Gregorian melodies. Specifically, ChantLab implements multiple sequence alignment and phylogenetic tree building, The application visualises the results through an interactive user interface, exports them in widely used formats, and supports custom dataset. ChantLab is available at https://quest.ms.mff.cuni.cz/chantlab},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Stutter_2025,
+  title = {{Towards New Representations and Methodologies for Detecting Concordances in Symbolic Music Corpora Pre-1600}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Stutter, Joshua},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {164--166},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/hxt3k-kcx31},
+  urldate = {2025-07-08},
+  abstract = {This poster investigates new methodologies for feature extraction and representation learning in detecting concordances within pre-1600 symbolic music corpora. Unlike the fixed and discrete works of the common practice period, Medieval and Renaissance music often survives in multiple, divergent versions, giving rise to complex intertextual relationships. While traditional catalogues raisonn{\'e}s and rules-based computational tools have made significant contributions to concordance detection, they are limited by their reliance on hand-crafted features that struggle to capture the more fluid, formulaic aspects of early music. Responding to recent critiques that the small size of early music datasets limits the applicability of post-2020 AI methods, this study argues instead that the challenge lies in how early notation is represented for computational analysis. Using the CANDR dataset of 13th-century polyphony, three feature extraction methodologies are evaluated: hand-crafted melodic features (via jSymbolic and music21), learned monophonic embeddings using Word2Vec, and polyphonic graph-based embeddings using a relational graph convolutional network (R-GCN). Each resulting vector space is assessed using silhouette score, Calinski--Harabasz index, and logistic regression classification. The analysis demonstrates that while all approaches offer insights, R-GCN-based representation learning outperforms hand-crafted feature extraction across all metrics by capturing richer polyphonic context and hierarchical structure. These findings suggest that, contrary to claims of data paucity, early music contains substantial untapped data potential when approached with appropriate representation learning methods. The poster argues for developing new methodologies grounded in learned representations to advance the detection and understanding of concordances in early music.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Alemayehu_2025,
+  title = {{Community-Driven Open Source Development of Edirom Online 1.0 and Beyond}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Alemayehu, Hizkiel and Bachmann, Tobias and Beer, Nikolaos and Bohl, Benjamin and Friedl, Dennis and R{\"o}wenstrunk, Daniel and Ried, Dennis and Herold, Kristin and Jettka, Daniel and Kepper, Johannes and Reich, Silke and Stadler, Peter},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {167--170},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/9q5gf-sbn97},
+  urldate = {2025-07-08},
+  abstract = {Edirom-Online is a software for the presentation and analysis of critical musical editions in a digital format, particularly in the fields of musicology and philology. Edirom-Online supports various data formats commonly used in digital humanities, such as TEI (Text Encoding Initiative) for textual data and MEI (Music Encoding Initiative) for musical data, that is visualized with Verovio. This allows for the integration of different data formats, starting in the early days with texts, images and music and adding audio and even film within a single edition. The Edirom idea was born in 2004 at Musikwissenschaftliches Seminar Detmold/Paderborn and even after several years of Edirom development, the success of Edirom based on the same core concepts as in the beginning continues with numerous projects using and developing Edirom tools and creating digital musical editions with this software. Edirom tools were originally developed by the project Entwicklung von Werkzeugen f{\"u}r digitale Formen wissenschaftlich-kritischer Musikeditionen (2006--2012) funded by the DFG. The development of Edirom is now maintained as a community effort while being strongly supported and accompanied by Virtueller Forschungsverbund Edirom (ViFE), primarily based at Paderborn University. This poster aims to celebrate the release of the first stable version of Edirom and as a demonstration of successful collaboration in open source research software development.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Wissmann_2025,
+  title = {{Stravinskys Way of Sketching -- A Digital Preparation of the Sketches for \textit{Le Sacre Du Printemps}}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Wi{\ss}mann, Jelena},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {171--172},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/f4wk6-g4f42},
+  urldate = {2025-07-08},
+  abstract = {The premiere of \textit{Le Sacre du Printemps} has been the subject of much discussion within the field of musicology due to the perceived scandal surrounding the piece. Nevertheless, the work is widely regarded as one of the most significant compositions of the 20th century. Despite this recognition, the genesis of the piece remains underexplored, as no musical edition of the work or its sketches currently exists. This project seeks to address this gap by creating an initial approach of a digital edition that not only provides access to Stravinsky's original sketches and their edited versions but also offers insights into his compositional process. The focus is on the section "Les Augures printaniers", allowing a detailed reconstruction of its compositional development. The sketches were edited according to standard practices, annotated, and encoded using the Music Encoding Initiative (MEI) standards to ensure machine readability. The Verovio software was used for visualization, enabling direct comparisons between sketches and the final score, presented on the created website. The chronological organization of the sketches reveals Stravinsky's method of mechanically assembling motifs into larger structures rather than developing them organically. This approach highlights Stravinsky's special compositional strategies and offers new perspectives on his creative process. By combining edited sketches, textual analysis, graphical representations, and digital tools, the project proposes a model for the digital edition of Le Sacre du Printemps, demonstrating the value of such editions for musicological research.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Peter_2025,
+  title = {{How to Infer Repeat Structures in MIDI Performances}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Peter, Silvan David and Hu, Patricia and Widmer, Gerhard},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {173--177},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/vbe6s-rds89},
+  urldate = {2025-07-09},
+  abstract = {MIDI performances are generally expedient in performance research and music information retrieval, and even more so if they can be connected to a score (Cancino-Chac{\'o}n et al., 2018, Peter et al., 2023). This connection is usually established by means of alignment, linking either notes or time points between the score and the performance. The first obstacle when trying to establish such an alignment is that a performance realizes one (out of many) structural versions of the score that can plausibly result from instructions such as repeats, variations, and navigation markers like 'dal segno/da capo al coda'. A score needs to be unfolded, that is, its repeats and navigation markers need to be explicitly written out to create a single timeline without jumps matching the performance, before alignment algorithms can be applied. In the curation of large performance corpora this process is carried out manually, as no tools are available to infer the repeat structure of the performance (Bukey et al., 2024). To ease this process, we develop a method to automatically infer the repeat structure of a MIDI performance, given a symbolically encoded score including repeat and navigation markers. The intuition guiding our design is: 1) local alignment of every contiguous section of the score with a section of a performance containing the same material should receive low alignment cost, whereas local alignment with any other performance section should accrue a high cost. And 2) stitching local alignments together according to a valid structural version of the score should result in an approximate full alignment and correspondingly low global backtracking cost if the structural version corresponds to the performance, and high cost for all other, ill-fitting structural versions.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Cerveto-Serrano_2025,
+  title = {{\textit{kernpy}: A Humdrum **Kern Oriented Python Package for Optical Music Recognition Tasks}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {{Cerveto-Serrano}, Joan and Rizo, David and {Calvo-Zaragoza}, Jorge},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {178--183},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/qhvtd-hkv52},
+  urldate = {2025-07-09},
+  abstract = {We present kernpy, a Python package that provides comprehensive tools for working with symbolic modern and mensural notations in Humdrum format. It serves as an intermediary tool for data extraction and significantly enhances the performance of Optical Music Recognition Python workflows. kernpy addresses the scarcity of symbolic score datasets in **kern/**mens by enabling the creation of large-scale datasets. By integrating formal grammars, kernpy offers a unified software for handling Humdrum files within a single, cohesive and user-friendly interface. kernpy is a fully open-source project open to contributions available at https://github.com/OMR-PRAIG-UA-ES/kernpy.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Klauk_2025,
+  title = {{Visualizing Wagner: A Combined Annotational Approach to \textit{Siegfried} Act III}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Klauk, Stephanie and Schmolenzky, Pascal and Kleinertz, Rainer and Wei{\ss}, Christof and M{\"u}ller, Meinard},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {184--188},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/x2vba-xn564},
+  urldate = {2025-07-09},
+  abstract = {After the controversial large-scale analyses of Richard Wagner's Der Ring des Nibelungen by Alfred Lorenz, Anthony Newcomb was the first to present new perspectives on large-scale Wagner analysis in 1981. One of his examples was the first scene of the third act of Siegfried. Both Lorenz's and Newcomb's analyses will be evaluated and discussed using visualisations of computational analyses of harmony and tempo based on audio files.},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+@inproceedings{Garcia-Iasci_2025,
+  title = {{Evaluating Music Encoding Approaches: An Accuracy Analysis of Tools and Standards}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {{Garc{\'i}a-Iasci}, Patricia and Rizo, David and {Calvo-Zaragoza}, Jorge},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {189--194},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/eepkj-etq50},
+  urldate = {2025-07-09},
+  abstract = {This paper considers different approaches for music encoding, evaluating user experience, accessibility, and readability, and accuracy with different software programs which musicologist, researchers, and musicians commonly use. A selection of monophonic pieces from The Dance Music of Ireland have been encoded in PAEC, MEI, MusicXML, and **kern, using manual direct encoding strategies, notation programs, and different OMR procedures. The result allows us to identify the most convenient method according to the needs of each user in each context.},
   keywords = {mec-proceedings, mec-proceedings-2025},
   displayby = {Contributions from MEC 2025}	
 }
@@ -2281,35 +2288,59 @@ The future development of suitable software can facilitate interdisciplinary stu
   displayby = {Contributions from MEC 2025}	
 }
 
-@inproceedings{Stickler_2025,
-  title = {{A Minimal Publishing Model for Text and Music Notation}},
+@inproceedings{Mantica_2025,
+  title = {{Towards a Digital Critical Edition of the Operas of Vincenzo Bellini}},
   booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Stickler, Felicitas and Roeder, Torsten and Moss, Fabian C.},
+  author = {Mantica, Candida Billie and Meriani, Giovanni and Saccomano, Mark Scott and Maccarini, Francesco},
   editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
   year = {2025},
-  pages = {104--106},
+  pages = {201--204},
   publisher = {Knowledge Commons},
-  doi = {10.17613/fv740-yvf93},
-  urldate = {2025-07-08},
-  abstract = {This paper introduces a minimal publishing model tailored for digital editions that incorporate both text and music notation. While established encoding standards like TEI and MEI are well-suited for text or music individually, their integration poses significant challenges for interdisciplinary projects such as music theory treatises, composers' correspondence, and sheet music editions with peritexts. To address these issues, we propose a sustainable approach using Verovio and CeTEIcean for dynamic rendering, emphasizing direct data generation without intermediate formats. The proposed model simplifies data organization, synchronizes rendering processes, and ensures low-cost deployment through platforms like GitHub Pages and Zenodo. This method not only supports resource-constrained projects but also serves as a blueprint for the TEI Music SIG to harmonize text and music encoding. The approach will be implemented in the Digitizing the Dualism Debate project, aiming to enrich the presentation of dense text-music relationships and lay the groundwork for future digital editions of hybrid materials.},
+  doi = {10.17613/2qn07-r6523},
+  urldate = {2025-07-09},
+  abstract = {Established in 2003, the Edizione critica delle opere di Vincenzo Bellini (Milan, Ricordi) plans to publish all of Bellini's music in a critical edition, serving a dual purpose: philological, to render musical texts that reflect authorial intention; and practical, to provide users and performers with reliable scores that correct errors perpetuated by traditional editions. Its traditional printed book format presents, however, several practical limitations: a) it does not allow simultaneous visualization of alternative materials; b) users lack access to the sources on which the volumes are based; c) the text of the main score cannot be modified, preventing the use of alternative materials. This poster illustrates the research objectives of the NextGenerationEU-funded project VerDigital (University of Pavia), which intends to overcome these limitations by combining the meticulous editorial approach of the series with tools offered by digital musicology. Specifically, VerDigital will employ the Edirom digital tools and Verovio to develop two interconnected models. 1) A model of digital critical edition using Bellini's "Adelson e Salvini" as a case study. The model does not simply provide encodings (MEI) of the individual sources, which do not allow for the reconstruction of a complete edited text that can be used by performers. Instead, it also presents an encoding of the edited text, offering data to retrace the editorial process. Relying on a tailored combination of Edirom, MEI and Verovio, the model develops an interactive system of fruition, allowing performers to choose among alternative readings/versions to customize their score/parts. 2) The second model focuses on Bellini's so-called 'studi giornalieri', attesting the first phases of his creative process. The model aims at connecting two different encodings: a 'diplomatic-interpretive' one, based on the actual spatial organization of the annotations in the pages, and another 'linearized' transcription, centered on the textual features of every fragment.},
   keywords = {mec-proceedings, mec-proceedings-2025},
   displayby = {Contributions from MEC 2025}	
 }
 
-@inproceedings{Stutter_2025,
-  title = {{Towards New Representations and Methodologies for Detecting Concordances in Symbolic Music Corpora Pre-1600}},
+%%% -------------------------------
+%%% MEC 2025 Proceedings: Panels
+
+@inproceedings{Obert_2025,
+  title = {{Sketching Genetic Editions: Challenges and Opportunities}},
   booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Stutter, Joshua},
+  author = {Obert, Salome and Seipelt, Agnes and Paciotti, Alessandra and Raunisi, Cecilia and Rosendahl, Lisa},
   editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
   year = {2025},
-  pages = {164--166},
+  pages = {208--213},
   publisher = {Knowledge Commons},
-  doi = {10.17613/hxt3k-kcx31},
-  urldate = {2025-07-08},
-  abstract = {This poster investigates new methodologies for feature extraction and representation learning in detecting concordances within pre-1600 symbolic music corpora. Unlike the fixed and discrete works of the common practice period, Medieval and Renaissance music often survives in multiple, divergent versions, giving rise to complex intertextual relationships. While traditional catalogues raisonn{\'e}s and rules-based computational tools have made significant contributions to concordance detection, they are limited by their reliance on hand-crafted features that struggle to capture the more fluid, formulaic aspects of early music. Responding to recent critiques that the small size of early music datasets limits the applicability of post-2020 AI methods, this study argues instead that the challenge lies in how early notation is represented for computational analysis. Using the CANDR dataset of 13th-century polyphony, three feature extraction methodologies are evaluated: hand-crafted melodic features (via jSymbolic and music21), learned monophonic embeddings using Word2Vec, and polyphonic graph-based embeddings using a relational graph convolutional network (R-GCN). Each resulting vector space is assessed using silhouette score, Calinski--Harabasz index, and logistic regression classification. The analysis demonstrates that while all approaches offer insights, R-GCN-based representation learning outperforms hand-crafted feature extraction across all metrics by capturing richer polyphonic context and hierarchical structure. These findings suggest that, contrary to claims of data paucity, early music contains substantial untapped data potential when approached with appropriate representation learning methods. The poster argues for developing new methodologies grounded in learned representations to advance the detection and understanding of concordances in early music.},
+  doi = {10.17613/ryvf1-y3w06},
+  urldate = {2025-07-09},
+  abstract = {The digital humanities have been changing scholarly methodologies in musicology for quite a while now. With this panel we would like to explore the possibilities of musicological genetic editions also in the digital realm. Bringing together four doctoral students with different backgrounds, experts on various 19th century composers, the discussion aims to address critical questions about the nature, scope, and practical implementation of genetic criticism into digital editions. Our focus extends beyond the territory of the well known project Beethovens Werkstatt, examining how new approaches can accommodate a wide array of musical repertoires, sources, and creative processes. Each panelist will pitch their research, highlighting the unique selling points of their projects, the challenges posed by their sources, and the innovative models, tools and concepts used to address these challenges. The panel is organized around four case studies: the sketches and autograph manuscript for Beethoven's Bagatelle Op. 126, Franz Liszt's autograph manuscript for the Sonata in B minor, the preparatory materials for Carl Maria von Weber's opera Die drei Pintos, and the surviving compositional sketches of Johannes Brahms. Collectively, these studies offer a multifaceted view of how digital genetic editions can address diverse repertoires and reveal the creative dynamics embedded in musical documents. Digital genetic editions represent an attempt to document and analyze the creative process of composition through a dynamic representation of its textual and musical sources. These editions seek to move beyond the final stage of the work by shedding light on the intermediary stages of creation. Beethovens Werkstatt -- a joint research project by the Beethoven-Haus Bonn (Germany) and the Department of Musicology Detmold/Paderborn (Germany), funded by the Academy of Sciences and Literature Mainz (Germany) -- plays a pioneering role in the field of genetic text criticism in music and digital editions. It is a fundamental research project that, for the first time, presents a series of concepts and models, as well as a glossary, for the investigation of writing and compositional processes in music and their digital representation and communication. Each panelist will introduce a case study, illustrating how their project expands the boundaries of genetic editions and illustrates the extent to which the research subject could reuse the concepts and (data) models from Beethovens Werkstatt and where there is a need to modify or extend them. The case studies expand the focus beyond a single composer's workshop, addressing different genres/repertoires and creative contexts. They invite comparisons and contrasts, offering insights into how the lessons of Beethovens Werkstatt can be adapted to different challenges, from Liszt's fluid revisions to the openness of the Weber manuscript. The presented sources reveal distinct challenges and possibilities for genetic editions, also in digital form. By focusing on these themes, the panel aims to inspire a broader conversation about the future of digital genetic editions in musicology. Ultimately, this panel envisions a future where digital genetic editions become a central tool for understanding and engaging with the creative processes of composers.},
+  bibbase_note = {<span style="color: green; font-weight: bold">Panel.</span>},
   keywords = {mec-proceedings, mec-proceedings-2025},
   displayby = {Contributions from MEC 2025}	
 }
+
+@inproceedings{Kijas_2025,
+  title = {{Digital Pedagogy \& Public Musicology Round Table}},
+  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
+  author = {Kijas, Anna E. and Grimmer, Jessica and Wissner, Reba and Robin, William},
+  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
+  year = {2025},
+  pages = {214--215},
+  publisher = {Knowledge Commons},
+  doi = {10.17613/jtj6p-atz44},
+  urldate = {2025-07-09},
+  abstract = {Student-centered digital pedagogy and projects enable simultaneous engagement with music history and literature as content while developing expertise in critical digital literacy skills. Through assignments or projects that employ music encoding standards, data curation, or creation of public facing scholarship students develop transferable skills that can be applied beyond the classroom and academy. Their knowledge is made visible through open-access projects that can become a resource for future students or scholars in the form of encoding, mapping, and other novel forms of disseminating information. Furthermore, such publicly available forms of publication aim to be inclusive, projecting knowledge and resources beyond the academy. In this roundtable, we bring together scholars and practitioners with backgrounds in public musicology, digital humanities, libraries, archives, and music encoding who will share their experiences in leveraging digital humanities methods and tools to engage students in experiential praxis-centered music courses and projects. Drawing on experiences teaching a seminar on music and public scholarship, Will Robin will address how to teach students the concept of the public. One longstanding problem of the phrase "public musicology" has been the assumption that there is a single, unified "public" waiting for scholars to reach it; in this presentation, Robin will discuss the idea of publics: how to conceive work aimed towards imagined and real non-academic audiences, and how to help students execute projects that draw on existing publics or develop new ones. As part of the public musicology program at Columbus State University, students take four courses in which they undertake several digital musicology projects including editing and encoding music in manuscript form using MEI, database entry, and use of online digital content management systems for exhibits and archiving. After giving a brief overview of the program, Reba Wissner will discuss how music encoding and digital musicology are fundamental public musicology skills for every music student, and how these skills can be incorporated into almost any music history course. Working with information students presents a unique approach to digital musicology. With an emphasis on creating space for close reading, for preservation, and for generating material that will be useful to future users and researchers, students in a special topics course on Music Encoding at the University of Maryland School of Information encoded a corpus of works by Carrie Jacobs-Bond, based on archival manuscripts at the Library of Congress. They subsequently collaboratively wrote a best practices paper for others embarking on encoding projects. Jessical Grimmer will discuss how this course equips students with technical and conceptual skills in digital humanities fostering connections between scholarly work and public engagement. She will also highlight strategies for using MEI to create accessible, sustainable, and community-focused digital resources.},
+  bibbase_note = {<span style="color: green; font-weight: bold">Panel.</span>},
+  keywords = {mec-proceedings, mec-proceedings-2025},
+  displayby = {Contributions from MEC 2025}	
+}
+
+
+%%% -------------------------------
+%%% MEC 2025 Proceedings: Workshops
 
 @inproceedings{Thomae_2025,
   title = {{Navigating and Processing MEI Data with XPath and XSLT}},
@@ -2327,32 +2358,18 @@ The future development of suitable software can facilitate interdisciplinary stu
   displayby = {Contributions from MEC 2025}	
 }
 
-@inproceedings{Wissmann_2025,
-  title = {{Stravinskys Way of Sketching -- A Digital Preparation of the Sketches for "Le Sacre Du Printemps"}},
+@inproceedings{Page_2025,
+  title = {{Annotating Music Scores: Representing and Interacting with Annotations Using MEI and Verovio}},
   booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Wi{\ss}mann, Jelena},
+  author = {Page, Kevin R. and Pugin, Laurent and {M. Weigl}, David},
   editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
   year = {2025},
-  pages = {171--172},
+  pages = {222--225},
   publisher = {Knowledge Commons},
-  doi = {10.17613/f4wk6-g4f42},
-  urldate = {2025-07-08},
-  abstract = {The premiere of "Le Sacre du Printemps" has been the subject of much discussion within the field of musicology due to the perceived scandal surrounding the piece. Nevertheless, the work is widely regarded as one of the most significant compositions of the 20th century. Despite this recognition, the genesis of the piece remains underexplored, as no musical edition of the work or its sketches currently exists. This project seeks to address this gap by creating an initial approach of a digital edition that not only provides access to Stravinsky's original sketches and their edited versions but also offers insights into his compositional process. The focus is on the section "Les Augures printaniers", allowing a detailed reconstruction of its compositional development. The sketches were edited according to standard practices, annotated, and encoded using the Music Encoding Initiative (MEI) standards to ensure machine readability. The Verovio software was used for visualization, enabling direct comparisons between sketches and the final score, presented on the created website. The chronological organization of the sketches reveals Stravinsky's method of mechanically assembling motifs into larger structures rather than developing them organically. This approach highlights Stravinsky's special compositional strategies and offers new perspectives on his creative process. By combining edited sketches, textual analysis, graphical representations, and digital tools, the project proposes a model for the digital edition of Le Sacre du Printemps, demonstrating the value of such editions for musicological research.},
-  keywords = {mec-proceedings, mec-proceedings-2025},
-  displayby = {Contributions from MEC 2025}	
-}
-
-@inproceedings{Yang_2025,
-  title = {{Music with Numbers: Jianpu Number-Based Notation in Cultural Heritage and Digital Humanities}},
-  booktitle = {{Music Encoding Conference 2025 -- Book of Abstracts}},
-  author = {Yang, Rui and Giraud, Mathieu and Lev{\'e}, Florence},
-  editor = {Lewis, David and Plaksin, Anna and Stremel, Sophie},
-  year = {2025},
-  pages = {12--24},
-  publisher = {Knowledge Commons},
-  doi = {10.17613/cjjtg-yar17},
-  urldate = {2025-07-08},
-  abstract = {Number-based music notation (NMN) offers an intuitive way to represent music, using numbers to denote pitches. Widely used in Chinese music education, it serves both as an accessible entry point for learners and as a comprehensive system for expressing and conceptualising music. NMN's versatility and adaptability both stem from and are influenced by musical education systems across various cultures, helping students engage with music straightforwardly and effectively. We examine NMN's historical and modern usage in both Eastern and Western contexts, highlighting the extensive adoption of Jianpu in 20th and 21st-century China. We also explore its integration into computer music software, databases, and encodings. We discuss how NMN can represent both simple and complex musical structures, emphasizing its potential for broader incorporation into digital humanities initiatives, including encoding systems such as MEI.},
+  doi = {10.17613/8q6rc-es750},
+  urldate = {2025-07-09},
+  abstract = {This half-day workshop will address annotations of musical scores, considering their role and structure, and strategies for representing, encoding and visualising them. The workshop will combine presentations, discussion and hands-on activities with new versions of Verovio and mei-friend. Annotation is an activity common across many walks of life and, for music, it unites scholars, musicians, teachers and composers. The practice is extremely varied, both in the forms it takes and the purposes it serves, and it is used for both physical and digital material. Digital annotations refer to highlights, circles, references, links or other selections made on digital documents or media. User-generated annotations are increasingly seen as a key mechanism for the use and reuse of digital materials across a wide range of applications, while also enhancing the findability and accessibility of that media through its annotations. While the importance of annotations in music notation is generally acknowledged, there is less of a consensus on how best to integrate them into interoperable software applications. Annotations for music can encompass the association of textual observations with regions of a work; cross-reference between musical passages or from a musical passage to some other, non-musical, material; or they might include categorical or structured music-analytical annotations, such as metrical or harmonic labels; most commonly, perhaps, they are used by musicians and teachers for sharing or remembering aspects of musical interpretation. Approaches taken in the digital domain include graphical, drawn overlays on top of an engraved score (which is popular in software for musicians and teachers), the use of URLs to specify score regions to be extracted and drawn by a web service (EMA, used by the CRIM project), Web Annotations (a Linked Data standard used by the MELD framework) and the MEI element itself. Given this diversity, it is essential to align implementation to specific needs and use cases rather than assuming a universal solution. This workshop consolidates a review of existing digital score annotation implementations, presenting new recommendations for enhanced annotation practice in MEI, and with hands-on experiments for implementing these recommendations in Verovio and mei-friend.},
+  bibbase_note = {<span style="color: green; font-weight: bold">Workshop.</span>},
   keywords = {mec-proceedings, mec-proceedings-2025},
   displayby = {Contributions from MEC 2025}	
 }


### PR DESCRIPTION
This PR sorts the proceedings entries by page number, fixes some page numbers and includes the latex macro for italics in titles.

Since the changes are probably hard to track on GitHub, test rendering is here: https://musicenfanthen.github.io/bibbase-test/